### PR TITLE
Backoff retries

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,19 @@ Google Civic API client
 
 {:state [{:name "Colorado", :electionAdministrationBody {:name "Colorado Secretary of State", :electionInfoUrl "http://www.sos.state.co.us/pubs/elections/", :electionRegistrationUrl "http://www.sos.state.co.us/pubs/elections/vote/VoterHome.html", :electionRegistrationConfirmationUrl "http://www.sos.state.co.us/pubs/elections/vote/VoterHome.html", :absenteeVotingInfoUrl "http://www.sos.state.co.us/pubs/elections/referenceGuides/Mail-inVoting.pdf", :ballotInfoUrl "http://www.sos.state.co.us/pubs/elections/vote/VoterHome.html", :electionRulesUrl "http://www.sos.state.co.us/pubs/elections/LawsRules/lawRulesOpinions.html", :correspondenceAddress {:line1 "1700 Broadway Ste 270", :city "Denver", :state "Colorado", :zip "80290-1702"}}, :local_jurisdiction {:name "Denver", :electionAdministrationBody {:name "County Clerk and Recorder", :hoursOfOperation "", :correspondenceAddress {:line1 "", :city "", :state "CO", :zip ""}, :physicalAddress {:line1 "200 W. 14th Ave., Suite 100", :city "Denver", :state "CO", :zip "80204"}, :electionOfficials [{:name "Debra Johnson", :title "County Clerk and Recorder", :officePhoneNumber "(720) 913-8683", :faxNumber "(720) 913-8600", :emailAddress "voterregistration@denvergov.org"}]}, :sources [{:name "TurboVote", :official false}]}, :sources [{:name "TurboVote", :official false}]}], :normalizedInput {:line1 "123 Voter St", :city "Denver", :state "CO", :zip "80218"}, :election {:id "2000", :name "VIP Test Election", :electionDay "2013-06-06"}}
 
+## Backoff Retry
+
+Both elections and voter-info have a version that can be called to get backoff retry
+mechanics. In these cases, if the initial call returns either a server error or a 403
+error with one of several reasons that indicate a temporary rate limit has been exceeded,
+it will retry the call. You provide a retry-limit (the maximum number of retries, so total
+calls could be retry-limit + 1), and a backoff function, with which you should pause
+processing for as long as you deem appropriate.
+
+```clojure
+(voter-info "YOUR API KEY" "123 Main St Denver CO 80218" nil 10 #(Thread/sleep 1000))
+```
+
 ## License
 
 Copyright (C) 2012-2015 Wes Morgan
@@ -21,6 +34,9 @@ Copyright (C) 2012-2015 Wes Morgan
 Distributed under the Eclipse Public License, the same as Clojure.
 
 ## Changelog
+* 2.1.0 - Added optional backoff retry mechanics to deal with rate limiting
+
+* 2.0.1 - Return all of response except for `:kind` in `voter-info`
 
 * 2.0.0 - Now uses the v2 Civic Info API (v1 has been deprecated and shut down)
 

--- a/README
+++ b/README
@@ -19,12 +19,13 @@ Google Civic API client
 Both elections and voter-info have a version that can be called to get backoff retry
 mechanics. In these cases, if the initial call returns either a server error or a 403
 error with one of several reasons that indicate a temporary rate limit has been exceeded,
-it will retry the call. You provide a retry-limit (the maximum number of retries, so total
-calls could be retry-limit + 1), and a backoff function, with which you should pause
-processing for as long as you deem appropriate.
+it will retry the call. The optional retry-config parameter should be a hash suitable
+for configuring the `try-try-again` function from the [robert-the-bruce](https://github.com/joegallo/robert-bruce) library, but any `:return?` configuration will be overwritten.
 
 ```clojure
-(voter-info "YOUR API KEY" "123 Main St Denver CO 80218" nil 10 #(Thread/sleep 1000))
+(elections "YOUR API KEY" {:tries :unlimited :sleep 100 :decay :exponential})
+
+(voter-info "YOUR API KEY" "123 Main St Denver CO 80218" nil {:tries 10 :sleep 1000})
 ```
 
 ## License

--- a/README
+++ b/README
@@ -29,7 +29,7 @@ processing for as long as you deem appropriate.
 
 ## License
 
-Copyright (C) 2012-2015 Wes Morgan
+Copyright (C) 2012-2016 Democracy Works Inc
 
 Distributed under the Eclipse Public License, the same as Clojure.
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
 (defproject google-civic "2.1.0-SNAPSHOT"
   :description "Google Civic Info API client"
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-http "2.3.0"]
-                 [cheshire "5.6.3"]]
+                 [clj-http "3.3.0"]
+                 [cheshire "5.6.3"]
+                 [robert/bruce "0.8.0"]]
   :deploy-repositories {"releases" :clojars}
   :profiles {:dev {:dependencies [[clj-http-fake "1.0.2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,7 @@
-(defproject google-civic "2.0.2-SNAPSHOT"
+(defproject google-civic "2.1.0-SNAPSHOT"
   :description "Google Civic Info API client"
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-http "2.0.0"]
-                 [cheshire "5.5.0"]
-                 [slingshot "0.12.2"]]
+                 [clj-http "2.3.0"]
+                 [cheshire "5.6.3"]]
   :deploy-repositories {"releases" :clojars}
-  :profiles {:dev {:dependencies [[clj-http-fake "1.0.1"]]}})
+  :profiles {:dev {:dependencies [[clj-http-fake "1.0.2"]]}})

--- a/src/google_civic/core.clj
+++ b/src/google_civic/core.clj
@@ -1,7 +1,8 @@
 (ns google-civic.core
-  (:require [clj-http.client :as client]
+  (:require [clj-http.client :as http]
             [cheshire.core :as json]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [robert.bruce :as bruce]))
 
 (def api-root "https://www.googleapis.com/civicinfo/v2")
 
@@ -12,9 +13,9 @@
 (defn temporary-rate-limit?
   "True if the errors in the response only include errors from the
   temporary-rate-limit-reasons set and the code is 403."
-  [response body]
+  [response]
   (and (= 403 (:status response))
-       (let [errors (get-in body [:error :errors])
+       (let [errors (get-in response [:body :error :errors])
              reasons (->> errors (map :reason) set)]
          (and (seq reasons)
               (set/superset? temporary-rate-limit-reasons
@@ -23,10 +24,10 @@
 (defn can-retry?
   "We can retry if the response code indicates a server error, or
    if the error is deemed a temporary rate limit."
-  [response body]
+  [response]
   (cond
-    (client/server-error? response) true
-    (temporary-rate-limit? response body) true
+    (http/server-error? response) true
+    (temporary-rate-limit? response) true
     :else
     false))
 
@@ -34,43 +35,34 @@
   (str api-root endpoint))
 
 (defn api-response [api-key endpoint & [query-params]]
-  (let [url (api-url endpoint)]
-    (client/get url {:accept :json
-                     :throw-exceptions false
-                     :query-params (merge {:key api-key} query-params)})))
+  (let [url (api-url endpoint)
+        response
+        (http/get url {:accepts :json
+                       :throw-exceptions false
+                       :query-params (merge {:key api-key} query-params)})
+        json-body (json/parse-string (:body response) true)]
+    (assoc response :body json-body)))
 
 (defn api-req
   ([api-key endpoint]
    (api-req api-key endpoint nil))
   ([api-key endpoint query-params]
-   (api-req api-key endpoint query-params 0 nil))
-  ([api-key endpoint query-params retry-limit backoff-fn]
-   (loop [response (api-response api-key endpoint query-params)
-          counter 0]
-     (let [body (json/parse-string (:body response) true)]
-       (if (client/success? response)
-         body
-         (if (and (< counter retry-limit)
-                  (can-retry? response body))
-           (do (when backoff-fn
-                 (backoff-fn))
-               (recur (api-response api-key endpoint query-params)
-                      (inc counter)))
-           (assoc response :body body)))))))
+   (api-req api-key endpoint query-params nil))
+  ([api-key endpoint query-params retry-config]
+   (let [config (if (seq retry-config)
+                        (assoc retry-config :return? (complement can-retry?))
+                        {:tries 1})]
+     (bruce/try-try-again config api-response api-key endpoint query-params))))
 
 (defn elections
   "Retrieve election data from the Civic Info API with the given api-key.
 
-  The three-arity version adds a retry-limit and a backoff-fn. In these version,
-  certain error responses will result in retried, up to the retry-limit. The
-  backoff-fn is a fn you provide to have a pause period between retries of your
-  chosing. This is primarily intended to handle rate limit responses for going
-  over instantaneous or concurrent rate limits and slow things down, so
-  a variable pause of 1-3 seconds may be ideal."
+  The two-arity version adds a retry-config param that will be used to
+  configure backoff retries as per the `robert-the-bruce` library."
   ([api-key]
-   (elections 0 nil))
-  ([api-key retry-limit backoff-fn]
-   (let [response (api-req api-key "/elections" nil retry-limit backoff-fn)]
+   (elections nil))
+  ([api-key retry-config]
+   (let [response (api-req api-key "/elections" nil retry-config)]
      (if-let [elections (:elections response)]
        elections
        (:body response)))))
@@ -83,23 +75,18 @@
   The three-arity version adds an optional google-election-id which can help
   with getting better results when it's available.
 
-  The five-arity version adds a retry-limit and a backoff-fn. In these version,
-  certain error responses will result in retried, up to the retry-limit. The
-  backoff-fn is a fn you provide to have a pause period between retries of your
-  chosing. This is primarily intended to handle rate limit responses for going
-  over instantaneous or concurrent rate limits and slow things down, so
-  a variable pause of 1-3 seconds may be ideal."
+  The four-arity version adds a retry-config param that will be used to
+  configure backoff retries as per the `robert-the-bruce` library."
   ([api-key addr]
    (voter-info api-key addr nil))
   ([api-key addr election-id]
-   (voter-info api-key addr election-id 0 nil))
-  ([api-key addr election-id retry-limit backoff-fn]
+   (voter-info api-key addr election-id nil))
+  ([api-key addr election-id retry-config]
    (let [query-params {:address addr}
          query-params (if election-id
                         (merge query-params {:electionId election-id})
                         query-params)
-         response (api-req api-key "/voterinfo" query-params
-                           retry-limit backoff-fn)
+         response (api-req api-key "/voterinfo" query-params retry-config)
          voter-info (dissoc response :kind)]
      (if (empty? voter-info)
        (:body response)

--- a/src/google_civic/core.clj
+++ b/src/google_civic/core.clj
@@ -1,6 +1,7 @@
 (ns google-civic.core
   (:require [clj-http.client :as client]
             [cheshire.core :as json]
+            [clojure.set :as set]))
 
 (def api-root "https://www.googleapis.com/civicinfo/v2")
 
@@ -19,35 +20,87 @@
               (set/superset? temporary-rate-limit-reasons
                              reasons)))))
 
+(defn can-retry?
+  "We can retry if the response code indicates a server error, or
+   if the error is deemed a temporary rate limit."
+  [response body]
+  (cond
+    (client/server-error? response) true
+    (temporary-rate-limit? response body) true
+    :else
+    false))
+
 (defn api-url [endpoint]
   (str api-root endpoint))
 
 (defn api-response [api-key endpoint & [query-params]]
   (let [url (api-url endpoint)]
     (client/get url {:accept :json
+                     :throw-exceptions false
                      :query-params (merge {:key api-key} query-params)})))
 
 (defn api-req
-  ([api-key endpoint & [query-params]]
-   (try+
-     (let [response (api-response api-key endpoint query-params)]
-       (json/parse-string (:body response) true))
-     (catch Object response
-       (merge response {:body (json/parse-string (:body response) true)})))))
+  ([api-key endpoint]
+   (api-req api-key endpoint nil))
+  ([api-key endpoint query-params]
+   (api-req api-key endpoint query-params 0 nil))
+  ([api-key endpoint query-params retry-limit backoff-fn]
+   (loop [response (api-response api-key endpoint query-params)
+          counter 0]
+     (let [body (json/parse-string (:body response) true)]
+       (if (client/success? response)
+         body
+         (if (and (< counter retry-limit)
+                  (can-retry? response body))
+           (do (when backoff-fn
+                 (backoff-fn))
+               (recur (api-response api-key endpoint query-params)
+                      (inc counter)))
+           (assoc response :body body)))))))
 
-(defn elections [api-key]
-  (let [response (api-req api-key "/elections")]
-    (if-let [elections (:elections response)]
-      elections
-      (:body response))))
+(defn elections
+  "Retrieve election data from the Civic Info API with the given api-key.
 
-(defn voter-info [api-key addr & [election-id]]
-  (let [query-params {:address addr}
-        query-params (if election-id
-                       (merge query-params {:electionId election-id})
-                       query-params)
-        response (api-req api-key (str "/voterinfo") query-params)
-        voter-info (dissoc response :kind)]
-    (if (empty? voter-info)
-      (:body response)
-      voter-info)))
+  The three-arity version adds a retry-limit and a backoff-fn. In these version,
+  certain error responses will result in retried, up to the retry-limit. The
+  backoff-fn is a fn you provide to have a pause period between retries of your
+  chosing. This is primarily intended to handle rate limit responses for going
+  over instantaneous or concurrent rate limits and slow things down, so
+  a variable pause of 1-3 seconds may be ideal."
+  ([api-key]
+   (elections 0 nil))
+  ([api-key retry-limit backoff-fn]
+   (let [response (api-req api-key "/elections" nil retry-limit backoff-fn)]
+     (if-let [elections (:elections response)]
+       elections
+       (:body response)))))
+
+(defn voter-info
+  "Retrieve voter-info data from the Civic Info API with the given api-key
+  and address string, which should just be a space separated string of the
+  address components, e.g. '123 Main St Denver CO 80204'.
+
+  The three-arity version adds an optional google-election-id which can help
+  with getting better results when it's available.
+
+  The five-arity version adds a retry-limit and a backoff-fn. In these version,
+  certain error responses will result in retried, up to the retry-limit. The
+  backoff-fn is a fn you provide to have a pause period between retries of your
+  chosing. This is primarily intended to handle rate limit responses for going
+  over instantaneous or concurrent rate limits and slow things down, so
+  a variable pause of 1-3 seconds may be ideal."
+  ([api-key addr]
+   (voter-info api-key addr nil))
+  ([api-key addr election-id]
+   (voter-info api-key addr election-id 0 nil))
+  ([api-key addr election-id retry-limit backoff-fn]
+   (let [query-params {:address addr}
+         query-params (if election-id
+                        (merge query-params {:electionId election-id})
+                        query-params)
+         response (api-req api-key "/voterinfo" query-params
+                           retry-limit backoff-fn)
+         voter-info (dissoc response :kind)]
+     (if (empty? voter-info)
+       (:body response)
+       voter-info))))

--- a/src/google_civic/core.clj
+++ b/src/google_civic/core.clj
@@ -1,7 +1,6 @@
 (ns google-civic.core
   (:require [clj-http.client :as client]
             [cheshire.core :as json]
-            [slingshot.slingshot :refer [try+]]))
 
 (def api-root "https://www.googleapis.com/civicinfo/v2")
 

--- a/src/google_civic/core.clj
+++ b/src/google_civic/core.clj
@@ -4,6 +4,21 @@
 
 (def api-root "https://www.googleapis.com/civicinfo/v2")
 
+(def temporary-rate-limit-reasons
+  #{"concurrentLimitExceeded" "rateLimitExceeded"
+    "servingLimitExceeded" "userRateLimitExceeded"})
+
+(defn temporary-rate-limit?
+  "True if the errors in the response only include errors from the
+  temporary-rate-limit-reasons set and the code is 403."
+  [response body]
+  (and (= 403 (:status response))
+       (let [errors (get-in body [:error :errors])
+             reasons (->> errors (map :reason) set)]
+         (and (seq reasons)
+              (set/superset? temporary-rate-limit-reasons
+                             reasons)))))
+
 (defn api-url [endpoint]
   (str api-root endpoint))
 


### PR DESCRIPTION
Can do optional backoff/retry http calls to the API when the response comes back as either a server error or one (or more) of several 403 reasons that should indicate a temporary rate limit exceeded. See the Civic Info API errors [here](https://developers.google.com/civic-information/docs/v2/errors) and more importantly the standard errors [here](https://developers.google.com/civic-information/docs/v2/standard_errors).

Incorporating this will allow large scale operations to backoff when we might overwhelm Google, in particular the vote-tomorrow notifications.

Assigning @danielglauser 
